### PR TITLE
RLMDB-21: Add guardrails to knowledge bases

### DIFF
--- a/backend/bedrock_impl/src/handler.py
+++ b/backend/bedrock_impl/src/handler.py
@@ -15,13 +15,15 @@ def get_bedrock_client() -> AgentsforBedrockRuntimeClient:
 def get_bedrock_config() -> RetrieveAndGenerateConfigurationTypeDef:
     return RetrieveAndGenerateConfigurationTypeDef(
         type="KNOWLEDGE_BASE",
-        guardrailConfiguration = {
-            "guardrailId": "3x3fwig8roag",
-            "guardrailVersion": "1"
-        },
         knowledgeBaseConfiguration={
             "knowledgeBaseId": "XBOBJWN1MQ",
-            "modelArn": "anthropic.claude-3-5-sonnet-20240620-v1:0"
+            "modelArn": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+            "generationConfiguration": {
+                "guardrailConfiguration": {
+                    "guardrailId": "3x3fwig8roag",
+                    "guardrailVersion": "1",
+                }
+            }
         }
     )
 


### PR DESCRIPTION
Changes:
- Added guardrail configuration to the knowledge base

Testing Steps:
- Load up AWS console
- Navigate to Lambda
- Navigate to functions (check top left)
- Click rag-BedrockRagFunction
- Scroll down and navigate to test
- Create a new test and use the AWS API gateway proxy template
- Scroll down until you find "requestContext" and add:
"authorizer": {
      "claims": {
        "sub" : "user"
      }
    },
- Then scroll back up to the top where it says "body" and use this query "body": "{\"query\": \" Hi my name is <your_name> What is the content platform?\"}"
- Then click test
- Then change the query to have a swear word it in

Expected Behaviours:
- Guardrail should mask your name
- It should block any profanity

<img width="278" height="248" alt="image" src="https://github.com/user-attachments/assets/138240b3-97e3-4b64-955d-51315c66d766" />
<img width="465" height="252" alt="image" src="https://github.com/user-attachments/assets/3299ddf9-762d-4718-9af6-0ad9bfe20acb" />
<img width="722" height="506" alt="image" src="https://github.com/user-attachments/assets/7f3e6653-8a1a-415f-aaee-7fe83a270e74" />
<img width="497" height="136" alt="image" src="https://github.com/user-attachments/assets/805ca2e3-50f3-4ff9-b8df-9b2bbfe85468" />
<img width="328" height="120" alt="image" src="https://github.com/user-attachments/assets/5dd41f34-c2d8-41ae-b06b-d4f5f6397388" />
<img width="674" height="38" alt="image" src="https://github.com/user-attachments/assets/7e089726-b52a-4099-b67e-b7a7747a953c" />
 
