### PR TITLE
Fix conversation fetch

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -80,16 +80,16 @@ export default function App() {
     }
   }, [auth.isAuthenticated]);
 
+  const loadConversations = async () => {
+    if (auth.isAuthenticated && auth.user?.profile?.sub) {
+        const convos = await getConversations(auth.user.profile.sub, auth.user.id_token!);
+        const sortedConvos = convos.sort((a, b) => {
+          return new Date(b.last_updated).valueOf() - new Date (a.last_updated).valueOf()
+        })
+        setConversations(sortedConvos);
+    }
+  };
   useEffect(() => {
-    const loadConversations = async () => {
-      if (auth.isAuthenticated && auth.user?.profile?.sub) {
-          const convos = await getConversations(auth.user.profile.sub, auth.user.id_token!);
-          const sortedConvos = convos.sort((a, b) => {
-            return new Date(b.last_updated).valueOf() - new Date (a.last_updated).valueOf()
-          })
-          setConversations(sortedConvos);
-      }
-    };
     loadConversations();
   }, [auth.isAuthenticated, auth.user]);
 
@@ -287,6 +287,7 @@ export default function App() {
                 onSessionCreated={(newSessionId: string) => {
                   setActiveSession(newSessionId);
                 }}
+                loadConversations={loadConversations}
               />
             </FeedbackProvider>
           </QueryClientProvider>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -91,7 +91,7 @@ export default function App() {
       }
     };
     loadConversations();
-  }, [auth.isAuthenticated, auth.user, conversations]);
+  }, [auth.isAuthenticated, auth.user]);
 
   const handleSelectConversation = async (sessionId: string) => {
     setIsPanelOpen(false)

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -8,11 +8,13 @@ import { UserMessage } from "../models/models";
 type ChatWindowProps = {
   messages?: any[];
   onSessionCreated?: (sessionId: string) => void;
+  loadConversations: () => Promise<void>
 };
 
 const ChatWindow = ({
   messages: externalMessages,
   onSessionCreated,
+  loadConversations
 }: ChatWindowProps) => {
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const [sessionId, setSessionId] = useState<string>();
@@ -50,7 +52,7 @@ const ChatWindow = ({
     created_at: "",
     role: "ai",
   };
-
+console.log("mesages: " + JSON.stringify(messages))
   const addMessage = (message: Message) => {
     if (readOnly) {
       setReadOnly(false);
@@ -61,6 +63,9 @@ const ChatWindow = ({
         return messages;
       return [...messages, message];
     });
+    if (messages.length < 1) {
+      loadConversations(); // refetch conversations to show new one
+    }
   };
 
   const query = useBedrock(!readOnly ? lastUserMessage : undefined);

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -52,7 +52,7 @@ const ChatWindow = ({
     created_at: "",
     role: "ai",
   };
-console.log("mesages: " + JSON.stringify(messages))
+
   const addMessage = (message: Message) => {
     if (readOnly) {
       setReadOnly(false);
@@ -63,7 +63,7 @@ console.log("mesages: " + JSON.stringify(messages))
         return messages;
       return [...messages, message];
     });
-    if (messages.length < 1) {
+    if (messages.length > 0 === false) {
       loadConversations(); // refetch conversations to show new one
     }
   };


### PR DESCRIPTION
Changes:
- Fix issue where conversations were being requested too many times

Testing steps:
- Spin up local frontend only (no changes made to backend stack)
- Login and inspect element
- View previous chat while monitoring browser console
- Open sidebar then start a new chat

Expected behaviours:
- API requests should only appear in console when initially opening a new conversation or add a message
- Creating a new chat with sidebar open should still pop up